### PR TITLE
Move Import Plugin Settings In Browser Config To Its Own File

### DIFF
--- a/browser/import.js
+++ b/browser/import.js
@@ -1,0 +1,12 @@
+
+module.exports = {
+  extends: [
+    'plugin:import/react'
+  ],
+  rules: {
+    'import/extensions': ['warn', 'always', {
+      js: 'never',
+      jsx: 'never'
+    }]
+  },
+};

--- a/browser/index.js
+++ b/browser/index.js
@@ -1,10 +1,10 @@
-const { pluginConfigs, ifInstalled } = require('../utils/plugins');
+const { pluginConfigs } = require('../utils/plugins');
 
 module.exports = {
   extends: [
     require.resolve('../base/index.js'),
-    ...ifInstalled('browser', 'eslint-plugin-import', 'plugin:import/react'),
     ...pluginConfigs('browser', __dirname, [
+      'import',
       'react',
       'react-hooks',
       'jsx-a11y',
@@ -19,11 +19,5 @@ module.exports = {
   },
   env: {
     browser: true
-  },
-  rules: {
-    'import/extensions': ['warn', 'always', {
-      js: 'never',
-      jsx: 'never'
-    }]
-  },
+  }
 };


### PR DESCRIPTION
This is so the import rules/settings get properly excluded when the `eslint-plugin-import` is not installed. Otherwise eslint will error something like `Definition for rule 'import/extensions' was not found.`