### PR TITLE
Reduce `react-hooks/exhaustive-deps` Rule To `warn`

### DIFF
--- a/browser/react-hooks.js
+++ b/browser/react-hooks.js
@@ -4,6 +4,6 @@ module.exports = {
   ],
   rules: {
     'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'error'
+    'react-hooks/exhaustive-deps': 'warn'
   }
 };


### PR DESCRIPTION
There are too many cases where a hook does not include something in the dependencies array on purpose. 