### PR TITLE
Relax Quotes & Default Export Rules

### DIFF
--- a/base/eslint.js
+++ b/base/eslint.js
@@ -15,9 +15,9 @@ module.exports = {
     'indent': ['warn', 2],
     'no-console': 'error',
     'no-trailing-spaces': 'warn',
-    'no-unused-vars': ['error', { 'args': 'none', 'ignoreRestSiblings': true }],
+    'no-unused-vars': ['error', { args: 'none', ignoreRestSiblings: true }],
     'prefer-const': 'warn',
-    'quotes': ['warn', 'single'],
+    'quotes': ['warn', 'single', { avoidEscape: true }],
     'semi': 'error',
   },
 };

--- a/base/import.js
+++ b/base/import.js
@@ -11,5 +11,6 @@ module.exports = {
     'import/extensions': ['warn', 'always', {
       js: 'never'
     }],
+    'import/prefer-default-export': 'off',
   },
 };


### PR DESCRIPTION
 - Tweak `quotes` rule to allow non-single quotes around strings containing single quotes ([docs](https://eslint.org/docs/rules/quotes))
 - Turn off `import/prefer-default-export` rule (allow named export in a file with only one export) ([docs](https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/prefer-default-export.md))