### PR TITLE
Make Optional Peer Dependencies Truely Optional & Peers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @LifewayIT/corinth

--- a/README.md
+++ b/README.md
@@ -47,14 +47,14 @@ All of the version requirements of these dependencies are very loose, just to en
 
 **Required by all configs:**
  - `eslint >= 6`
- - `eslint-plugin-jest : ^23.6.0`
- - `eslint-plugin-import : ^2.20.0`
+ - `eslint-plugin-jest : >=23.6.0`
+ - `eslint-plugin-import : >=2.20.0`
 
 **Additional optional dependencies:**
- - `eslint-plugin-react : ^7.18.3` - when using the `browser` config
- - `eslint-plugin-react-hooks : ^2.0.0` - when using the `browser` config
- - `eslint-plugin-jsx-a11y : ^6.2.3` - when using the `browser` config
- - `eslint-plugin-testing-library : ^3.4.0` - when using the `browser` config
- - `eslint-plugin-jest-dom : ^3.1.4` - when using the `browser` config
- - `@typescript-eslint/parser : ^2.19.0` - when using the `typescript` config
- - `@typescript-eslint/eslint-plugin : ^2.19.0` - when using the `typescript` config
+ - `eslint-plugin-react : >=7.18.3` - when using the `browser` config
+ - `eslint-plugin-react-hooks : >=2.0.0` - when using the `browser` config
+ - `eslint-plugin-jsx-a11y : >=6.2.3` - when using the `browser` config
+ - `eslint-plugin-testing-library : >=3.4.0` - when using the `browser` config
+ - `eslint-plugin-jest-dom : >=3.1.4` - when using the `browser` config
+ - `@typescript-eslint/parser : >=2.19.0` - when using the `typescript` config
+ - `@typescript-eslint/eslint-plugin : >=2.19.0` - when using the `typescript` config

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "eslint-plugin-import": "^2.20.0",
     "eslint-plugin-jest": "^23.6.0"
   },
-  "optionalDependencies": {
+  "optionalPeerDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.19.0",
     "@typescript-eslint/parser": "^2.19.0",
     "eslint-plugin-jest-dom": "^3.1.4",

--- a/package.json
+++ b/package.json
@@ -11,17 +11,17 @@
   "license": "ISC",
   "peerDependencies": {
     "eslint": ">= 6",
-    "eslint-plugin-import": "^2.20.0",
-    "eslint-plugin-jest": "^23.6.0"
+    "eslint-plugin-import": ">=2.20.0",
+    "eslint-plugin-jest": ">=23.6.0"
   },
   "optionalPeerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.19.0",
-    "@typescript-eslint/parser": "^2.19.0",
-    "eslint-plugin-jest-dom": "^3.1.4",
-    "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-react": "^7.18.3",
-    "eslint-plugin-react-hooks": "^2.0.0",
-    "eslint-plugin-testing-library": "^3.4.0"
+    "@typescript-eslint/eslint-plugin": ">=2.19.0",
+    "@typescript-eslint/parser": ">=2.19.0",
+    "eslint-plugin-jest-dom": ">=3.1.4",
+    "eslint-plugin-jsx-a11y": ">=6.2.3",
+    "eslint-plugin-react": ">=7.18.3",
+    "eslint-plugin-react-hooks": ">=2.0.0",
+    "eslint-plugin-testing-library": ">=3.4.0"
   },
   "dependencies": {
     "babel-eslint": "^10.0.3"

--- a/typescript/import.js
+++ b/typescript/import.js
@@ -1,0 +1,20 @@
+module.exports = {
+  plugins: [
+    'import'
+  ],
+  extends: [
+    'plugin:import/typescript'
+  ],
+  rules: {
+    'import/extensions': ['warn', 'always', {
+      js: 'never',
+      ts: 'never'
+    }]
+  },
+  settings: {
+    'import/extensions': ['.js', '.ts'],
+    // 'import/parsers': {
+    //   '@typescript-eslint/parser': ['.ts'],
+    // },
+  }
+}

--- a/typescript/ts.js
+++ b/typescript/ts.js
@@ -1,0 +1,17 @@
+module.exports = {
+  plugins: [
+    '@typescript-eslint'
+  ],
+  parser: '@typescript-eslint/parser',
+  extends: [
+    'plugin:@typescript-eslint/eslint-recommended', // now bundled in with ts-eslint/recommended
+    'plugin:@typescript-eslint/recommended'
+    // also ts-eslint/recommended-requiring-type-checking ?
+  ],
+  rules: {
+    '@typescript-eslint/no-use-before-define': ['error', { 'classes': false }],
+    '@typescript-eslint/no-explicit-any': 'warn',
+    '@typescript-eslint/no-unused-vars': ['error', { 'args': 'none', 'ignoreRestSiblings': true }],
+    '@typescript-eslint/explicit-function-return-type': 'off',
+  },
+}


### PR DESCRIPTION
The packages under `optionalDependecies` should actually be `optionalPeerDependencies` (non-standard field). `optionalDependecies` are automatically installed (unless the `--no-optional` flag is used) which is not desired. Rather these are optional _peer_ dependencies, so it is the user's responsibility to install the right ones & npm will not warn if some are not installed.

Also, this package already has logic to print a warning if a config is used without all its dependencies installed.